### PR TITLE
:sparkles: new common component added

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 
+    // Icons library
+    implementation("androidx.compose.material:material-icons-extended:1.5.4")
+
     // OkHttp para logging (opcional pero útil)
     implementation("com.squareup.okhttp3:logging-interceptor:4.11.0")
     

--- a/app/src/main/java/com/uniandes/vynilapp/MainActivity.kt
+++ b/app/src/main/java/com/uniandes/vynilapp/MainActivity.kt
@@ -1,15 +1,19 @@
 package com.uniandes.vynilapp
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import com.uniandes.vynilapp.ui.theme.VynilappTheme
 import com.uniandes.vynilapp.views.AlbumsScreen
+import com.uniandes.vynilapp.views.ArtistsScreen
+import com.uniandes.vynilapp.views.CollectionsScreen
+import com.uniandes.vynilapp.views.common.BottomNavigationBar
+import com.uniandes.vynilapp.views.common.NavigationItem
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,10 +23,35 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             VynilappTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { paddingValues ->
-                    AlbumsScreen(modifier = Modifier.padding(paddingValues))
-                }
+                MainScreen()
             }
+        }
+    }
+}
+
+@Composable
+fun MainScreen() {
+    var selectedTab by remember { mutableStateOf(NavigationItem.ALBUMS) }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        bottomBar = {
+            BottomNavigationBar(
+                selectedTab = selectedTab,
+                onTabSelected = { selectedTab = it }
+            )
+        }
+    ) { paddingValues ->
+        when (selectedTab) {
+            NavigationItem.ALBUMS -> AlbumsScreen(
+                modifier = Modifier.padding(paddingValues)
+            )
+            NavigationItem.ARTISTS -> ArtistsScreen(
+                modifier = Modifier.padding(paddingValues)
+            )
+            NavigationItem.COLLECTIONS -> CollectionsScreen(
+                modifier = Modifier.padding(paddingValues)
+            )
         }
     }
 }

--- a/app/src/main/java/com/uniandes/vynilapp/views/ArtistActivity.kt
+++ b/app/src/main/java/com/uniandes/vynilapp/views/ArtistActivity.kt
@@ -1,0 +1,40 @@
+package com.uniandes.vynilapp.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ArtistsScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0xFF111120))
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Artists",
+                color = Color.White,
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "Coming soon...",
+                color = Color.Gray,
+                fontSize = 16.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vynilapp/views/CollectionsActivity.kt
+++ b/app/src/main/java/com/uniandes/vynilapp/views/CollectionsActivity.kt
@@ -1,0 +1,40 @@
+package com.uniandes.vynilapp.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CollectionsScreen(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color(0xFF111120))
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Collections",
+                color = Color.White,
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "Coming soon...",
+                color = Color.Gray,
+                fontSize = 16.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vynilapp/views/common/BottomNavigation.kt
+++ b/app/src/main/java/com/uniandes/vynilapp/views/common/BottomNavigation.kt
@@ -1,0 +1,50 @@
+package com.uniandes.vynilapp.views.common
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class NavigationItem(
+    val title: String,
+    val icon: ImageVector,
+    val route: String
+) {
+    ALBUMS("Albums", Icons.Default.Album, "albums"),
+    ARTISTS("Artists", Icons.Default.Person, "artists"),
+    COLLECTIONS("Collections", Icons.Default.LibraryMusic, "collections")
+}
+
+@Composable
+fun BottomNavigationBar(
+    selectedTab: NavigationItem,
+    onTabSelected: (NavigationItem) -> Unit
+) {
+    NavigationBar(
+        containerColor = Color(0xFF1A1A2E),
+        contentColor = Color.White
+    ) {
+        NavigationItem.entries.forEach { item ->
+            NavigationBarItem(
+                icon = {
+                    Icon(
+                        imageVector = item.icon,
+                        contentDescription = item.title
+                    )
+                },
+                label = { Text(item.title) },
+                selected = selectedTab == item,
+                onClick = { onTabSelected(item) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = Color(0xFF6C63FF),
+                    selectedTextColor = Color(0xFF6C63FF),
+                    unselectedIconColor = Color.Gray,
+                    unselectedTextColor = Color.Gray,
+                    indicatorColor = Color(0xFF2D2D44)
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## ✨ Add Bottom Navigation Component

### Summary
Implemented a reusable bottom navigation bar with three tabs: Albums, Artists, and Collections.

### Key Features
- Material3 NavigationBar component with custom theming
- Three navigation items defined via enum (Albums, Artists, Collections)
- Dark theme color palette matching existing design (`#1A1A2E`, `#6C63FF`)
- Type-safe navigation structure with icons and routes

### Technical Implementation
- Component location: `views/common/BottomNavigation.kt`
- Uses Jetpack Compose + Material3
- Stateless component with callback pattern for tab selection

### Next Steps
- Implement Artists and Collections screens
- Integrate bottom nav into MainActivity

### Current View
<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/9fa51fd8-2e37-4e4e-85d2-e4266e1ff1fe" />
