### PR TITLE
update artist detail view

### DIFF
--- a/app/src/main/java/com/uniandes/vynilapp/views/ArtistDetailActivity.kt
+++ b/app/src/main/java/com/uniandes/vynilapp/views/ArtistDetailActivity.kt
@@ -2,6 +2,8 @@ package com.uniandes.vynilapp.views
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,6 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -29,11 +32,13 @@ import com.uniandes.vynilapp.views.common.TopBar
 import com.uniandes.vynilapp.views.states.ArtistDetailEvent
 import com.uniandes.vynilapp.views.states.ArtistDetailUiState
 import com.uniandes.vynilapp.R
+import com.uniandes.vynilapp.utils.DateUtils
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import android.util.Log
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
+import com.uniandes.vynilapp.model.ArtistAlbum
 
 @Composable
 fun ArtistDetailScreen(
@@ -80,6 +85,7 @@ fun ArtistDetailContent(
     onBack: () -> Unit
 ) {
     val artistDetailTitle = stringResource(id = R.string.artist_detail_title)
+    val artistDescriptionTitle = stringResource(id = R.string.artist_description_title)
     // Create a scroll state
     val scrollState = rememberScrollState()
 
@@ -103,7 +109,6 @@ fun ArtistDetailContent(
             // Artist Info Card
             Column(
                 modifier = Modifier
-                    .padding(24.dp)
                     .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
@@ -122,6 +127,15 @@ fun ArtistDetailContent(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
+                Text(
+                    text = artistDescriptionTitle,
+                    color = Color.White,
+                    fontSize = 24.sp,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
                 uiState.artist?.description?.let {
                     Text(
                         text = it,
@@ -133,21 +147,166 @@ fun ArtistDetailContent(
 
             Spacer(modifier = Modifier.height(24.dp))
 
+            if (uiState.albums.isNotEmpty()) {
+                ArtistAlbums(
+                    albums = uiState.albums,
+                    onAlbumClick = { albumId ->
+                        Log.d("ArtistDetail", "Album clicked: $albumId")
+                        // TODO: Navigate to album detail
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
             // Additional Info Section
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                ArtistInfoRow(label = "Genre", value = "Various")
-                ArtistInfoRow(label = "Albums", value = "Coming soon")
-                ArtistInfoRow(label = "Popularity", value = "★★★★☆")
-                ArtistInfoRow(label = "Country", value = "Panama")
-                ArtistInfoRow(label = "Active Since", value = "1970")
-                ArtistInfoRow(label = "Label", value = "Sony Music")
+                val popularity = stringResource(id = R.string.artist_additional_info_popularity)
+                val birthDate = stringResource(id = R.string.artist_additional_info_birth_date)
+                ArtistInfoRow(label = birthDate, value = DateUtils.formatAlbumDate(uiState.artist?.birthDate))
+                ArtistInfoRow(label = popularity, value = "★★★★☆")
             }
 
             // Add bottom padding for better scrolling experience
             Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+fun AlbumCard(
+    album: ArtistAlbum,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .width(140.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color(0xFF111120)
+        )
+    ) {
+        Column {
+            // Album Cover Image
+            SubcomposeAsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(album.cover)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = album.name,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(140.dp)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomEnd = 8.dp, bottomStart = 8.dp)),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xFF2A2A3E)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            color = Color(0xFF6C63FF),
+                            modifier = Modifier.size(30.dp)
+                        )
+                    }
+                },
+                error = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xFF2A2A3E)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "♪",
+                            fontSize = 40.sp,
+                            color = Color.Gray
+                        )
+                    }
+                }
+            )
+
+            // Album Info
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                Text(
+                    text = album.name,
+                    color = Color.White,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    text = DateUtils.formatAlbumYear(album.releaseDate),
+                    color = Color.Gray,
+                    fontSize = 11.sp
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+fun ArtistAlbums(
+    albums: List<ArtistAlbum>,
+    onAlbumClick: (Int) -> Unit = {}
+) {
+    if (albums.isEmpty()) {
+        // Show empty state
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "No albums available",
+                color = Color.Gray,
+                fontSize = 14.sp,
+                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+            )
+        }
+    } else {
+        val artistAlbumsTitle = stringResource(id = R.string.artist_album_title)
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Section Title
+            Text(
+                text = artistAlbumsTitle,
+                color = Color.White,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            // Horizontal Scrolling Row
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                albums.forEach { album ->
+                    AlbumCard(
+                        album = album,
+                        onClick = { onAlbumClick(album.id) }
+                    )
+                }
+            }
         }
     }
 }
@@ -258,6 +417,36 @@ fun ArtistInfoRow(label: String, value: String) {
 )
 @Composable
 fun PreviewArtistDetailWithAlbums() {
+    val mockAlbums = listOf(
+        ArtistAlbum(
+            id = 1,
+            name = "Buscando América",
+            cover = "https://i.pravatar.cc/300",
+            releaseDate = "1984-08-01T00:00:00.000Z",
+            description = "Classic salsa album",
+            genre = "Salsa",
+            recordLabel = "Elektra"
+        ),
+        ArtistAlbum(
+            id = 2,
+            name = "Siembra",
+            cover = "https://i.pravatar.cc/300",
+            releaseDate = "1978-09-01T00:00:00.000Z",
+            description = "Iconic album",
+            genre = "Salsa",
+            recordLabel = "Fania"
+        ),
+        ArtistAlbum(
+            id = 3,
+            name = "Amor y Control",
+            cover = "https://i.pravatar.cc/300",
+            releaseDate = "1992-01-01T00:00:00.000Z",
+            description = "Great album",
+            genre = "Latin",
+            recordLabel = "Sony"
+        )
+    )
+
     val mockUiState = ArtistDetailUiState(
         artist = Artist(
             id = 104,
@@ -265,10 +454,10 @@ fun PreviewArtistDetailWithAlbums() {
             image = null,
             description = "English rock band formed in London in 1965, known for progressive and psychedelic music.",
             birthDate = "1965-01-01T00:00:00.000Z",
-            albums = emptyList(),
+            albums = mockAlbums,
             performerPrizes = emptyList()
         ),
-        albums = emptyList(),
+        albums = mockAlbums,
         performerPrizes = emptyList(),
         isLoading = false,
         error = null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,8 @@
 <resources>
     <string name="app_name">Vynilapp</string>
     <string name="artist_detail_title">Artista</string>
+    <string name="artist_album_title">Discrografía</string>
+    <string name="artist_description_title">Biografia</string>
+    <string name="artist_additional_info_birth_date">Fecha de nacimiento</string>
+    <string name="artist_additional_info_popularity">Popularity</string>
 </resources>


### PR DESCRIPTION
## 🎨 Update Artist Detail View with Albums Display

### Summary
Added a horizontal scrolling carousel to display artist albums in the artist detail view with rich album cards showing cover images, names, genres, and release years.

### Key Changes
- ✨ New `ArtistAlbums()` composable with horizontal scroll
- 🎴 `AlbumCard()` component with image loading states
- 🔧 Custom ImageLoader with SSL certificate handling
- 📱 Responsive album card design (140dp width)
- 🎯 Click handling prepared for album navigation
- 📝 Replaced print statements with proper Logcat logging

### Technical
- Used Coil's `SubcomposeAsyncImage` for image loading
- Connected to `ArtistDetailUiState.albums`
- Added empty state handling
- Configured SSL trust manager in `VinylApplication`

### Visual Impact
Users can now browse an artist's albums horizontally with rich visual cards showing album artwork and metadata.

|Screenshot 1| Screenshot 2| Screenshot 3|
|------|---------|---------|
|<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/af1d3d79-44a1-4c9c-bd65-06e0fc8abd64" />|<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/1a5f8fcb-23bc-4256-b38b-cc20702f8190" />|<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/2d8236e3-343d-4362-b436-43eb470a070c" />|
